### PR TITLE
Add VISUAL placeholder to desc snippet

### DIFF
--- a/UltiSnips/javascript_jest.snippets
+++ b/UltiSnips/javascript_jest.snippets
@@ -110,7 +110,7 @@ endsnippet
 
 snippet desc "Jest - describe(name, fn)"
 describe('$1', () => {
-	$2
+	${VISUAL}$0
 });
 endsnippet
 


### PR DESCRIPTION
Now if you start off by visual-selecting several lines of text, then trigger the `desc` snippet from Visual mode, then the `describe` block will be pre-filled with the text that you had selected.

This is useful for selecting some existing `test`/`it` blocks and wrapping them in a new `describe` block.

Example:
![https://thumbs.gfycat.com/CleverFluffyCaudata-size_restricted.gif](https://thumbs.gfycat.com/CleverFluffyCaudata-size_restricted.gif)

FWIW this approach is used in a lot of other javascript snippets https://github.com/honza/vim-snippets/search?p=2&q=VISUAL&type=&utf8=%E2%9C%93